### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Lykke.WalletApiv2.Tests/Lykke.WalletApiv2.Tests.csproj
+++ b/Lykke.WalletApiv2.Tests/Lykke.WalletApiv2.Tests.csproj
@@ -10,13 +10,13 @@
     <None Remove="Registration\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.1" />
+    <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
Hi@KonstantinRyazantsev, I found an issue in the Lykke.WalletApiv2.Tests.csproj:

Packages Autofac v4.9.1, Microsoft.AspNetCore.TestHost v2.1.1, Microsoft.NET.Test.Sdk v15.9.0, Moq v4.10.1, NUnit v3.11.0 and NUnit3TestAdapter v3.12.0 transitively introduce 97 dependencies into LykkeWalletAPI’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/LykkeWalletAPI.html)), while Autofac v4.9.4, Microsoft.AspNetCore.TestHost v2.2.0, Microsoft.NET.Test.Sdk v15.9.1, Moq v4.15.2, NUnit v3.13.2 and NUnit3TestAdapter v4.0.0 can only introduce 69 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/LykkeWalletAPI_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose