### PR TITLE
LM-2769 Fix Broken tests

### DIFF
--- a/LykkeApi2/Modules/Api2Module.cs
+++ b/LykkeApi2/Modules/Api2Module.cs
@@ -126,7 +126,7 @@ namespace LykkeApi2.Modules
                 .SingleInstance();
 
             builder.RegisterInstance(settings.SessionCheck);
-            builder.RegisterInstance(settings.PrivateWallet);
+            builder.RegisterInstance(settings.PrivateWallet ?? new PrivateWalletSettings());
             builder.RegisterInstance(_apiSettings.CurrentValue.BlockedWithdrawalSettings);
             builder.RegisterType<SiriusWalletsService>()
                 .As<ISiriusWalletsService>()


### PR DESCRIPTION
Fix Test:
```

System.ArgumentNullException : Value cannot be null. (Parameter 'instance')
   at Autofac.RegistrationExtensions.RegisterInstance[T](ContainerBuilder builder, T instance)
at LykkeApi2.Modules.Api2Module.BindServices(ContainerBuilder builder, BaseSettings settings) in /opt/buildagent/work/a765dd5e65fbedaf/LykkeApi2/Modules/Api2Module.cs:line 129
at LykkeApi2.Modules.Api2Module.Load(ContainerBuilder builder) in /opt/buildagent/work/a765dd5e65fbedaf/LykkeApi2/Modules/Api2Module.cs:line 96
at Autofac.Module.Configure(IComponentRegistry componentRegistry)
at Autofac.ContainerBuilder.Build(IComponentRegistry componentRegistry, Boolean excludeDefaultModules)
at Autofac.ContainerBuilder.Build(ContainerBuildOptions options)
at Lykke.WalletApiv2.Tests.DITests.DiTests.Init() in /opt/buildagent/work/a765dd5e65fbedaf/Lykke.WalletApiv2.Tests/DITests/DITests.cs:line 96
[Open in build log](https://teamcity-sw.lykkex.net/buildConfiguration/WalletAPIV2_BuildTest/170133?showLog=170133_966_966)
```